### PR TITLE
bugfix: use query parameter value to understand if value should be urlencoded

### DIFF
--- a/Service/Request/RequestFactory.php
+++ b/Service/Request/RequestFactory.php
@@ -173,13 +173,21 @@ class RequestFactory implements RequestFactoryInterface
      */
     private function parseQueryParams(string $path): array
     {
+        $queryParamsArray = [];
         $queryParamsString = parse_url($path, PHP_URL_QUERY);
         if (null !== $queryParamsString) {
+            // $queryParamsArray: ['query-param' => '{queryParam}']
             parse_str($queryParamsString, $queryParamsArray);
 
-            return $queryParamsArray;
+            // $queryParamsArray: ['query-param' => 'queryParam']
+            $queryParamsArray = array_map(function($queryValue) {
+                return trim($queryValue, '{}');
+            }, $queryParamsArray);
+
+            // $queryParamsArray: ['queryParam' => 'query-param']
+            return array_flip($queryParamsArray);
         }
 
-        return [];
+        return $queryParamsArray;
     }
 }

--- a/Service/Request/RequestFactory.php
+++ b/Service/Request/RequestFactory.php
@@ -167,6 +167,10 @@ class RequestFactory implements RequestFactoryInterface
     }
 
     /**
+     * The query parameters aren't encoded for all GET requests.
+     * For example, "/v1/car-types/built-dates?country=CH&main-type=Qashqai+2&sort=&manufacturer=225" - here 
+     * "Qashqai+2" have to be "Qashqai%2B2".
+     *
      * @param string $path
      *
      * @return array

--- a/Tests/Service/Request/RequestFactoryTest.php
+++ b/Tests/Service/Request/RequestFactoryTest.php
@@ -169,7 +169,7 @@ class RequestFactoryTest extends TestCase
         $routeString = '/routeString?query-param={queryParam}';
         $originParamValue = 'value with whitespaces';
         $requestMethod = 'GET';
-        $requestBody = '{requestBody:requestBody}';
+        $requestBody = '';
 
         $expectedUri = 'baseUrl/routeString?query-param=value+with+whitespaces';
 

--- a/Tests/Service/Request/RequestFactoryTest.php
+++ b/Tests/Service/Request/RequestFactoryTest.php
@@ -166,12 +166,12 @@ class RequestFactoryTest extends TestCase
     public function testBuildFlowWithQueryParams()
     {
         $baseUrl = 'baseUrl';
-        $routeString = '/routeString?param={param}';
+        $routeString = '/routeString?query-param={queryParam}';
         $originParamValue = 'value with whitespaces';
         $requestMethod = 'GET';
         $requestBody = '{requestBody:requestBody}';
 
-        $expectedUri = 'baseUrl/routeString?param=value+with+whitespaces';
+        $expectedUri = 'baseUrl/routeString?query-param=value+with+whitespaces';
 
         $endpointProphecy = $this->prophesize(EndpointInterface::class);
         $endpointProphecy->__call('getBaseUrl', [])
@@ -236,12 +236,12 @@ class RequestFactoryTest extends TestCase
 
         // Mock non existing method of ServiceRequest `getParam`
         $serviceRequest = $this->getMockBuilder(ServiceRequestInterface::class)
-            ->setMethods(['getParam'])
+            ->setMethods(['getQueryParam'])
             ->getMock()
         ;
 
         $serviceRequest->expects($this->once())
-            ->method('getParam')
+            ->method('getQueryParam')
             ->willReturn($originParamValue)
         ;
 

--- a/Tests/Service/Request/RequestFactoryTest.php
+++ b/Tests/Service/Request/RequestFactoryTest.php
@@ -166,12 +166,12 @@ class RequestFactoryTest extends TestCase
     public function testBuildFlowWithQueryParams()
     {
         $baseUrl = 'baseUrl';
-        $routeString = '/routeString?query-param={queryParam}';
+        $routeString = '/routeString?first-param={firstParam}&second-param=ignored value';
         $originParamValue = 'value with whitespaces';
         $requestMethod = 'GET';
         $requestBody = '';
 
-        $expectedUri = 'baseUrl/routeString?query-param=value+with+whitespaces';
+        $expectedUri = 'baseUrl/routeString?first-param=value+with+whitespaces&second-param=ignored value';
 
         $endpointProphecy = $this->prophesize(EndpointInterface::class);
         $endpointProphecy->__call('getBaseUrl', [])
@@ -236,12 +236,12 @@ class RequestFactoryTest extends TestCase
 
         // Mock non existing method of ServiceRequest `getParam`
         $serviceRequest = $this->getMockBuilder(ServiceRequestInterface::class)
-            ->setMethods(['getQueryParam'])
+            ->setMethods(['getFirstParam'])
             ->getMock()
         ;
 
         $serviceRequest->expects($this->once())
-            ->method('getQueryParam')
+            ->method('getFirstParam')
             ->willReturn($originParamValue)
         ;
 


### PR DESCRIPTION
In previous PR (https://github.com/auto1-oss/service-api-client-bundle/pull/10) the query param value should be used to check if DTO property value has to be urlencoded.