### PR TITLE
Make this package compatible with PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
         "symfony/http-kernel": "~3.0|~4.0|~5.0",
         "symfony/property-info": "^3.4.2|~4.0|~5.0",
         "monolog/monolog": "~1.22",
-        "php-http/client-common": "^1.5",
+        "php-http/client-common": "^2.3",
         "php-http/discovery": "^1.3",
-        "php-http/httplug": "^1.1",
+        "php-http/httplug": "^2.2",
         "psr/http-message": "^1.0",
         "psr/log": "^1.1"
     },


### PR DESCRIPTION
Because `php-http/client-common` allows PHP 8.0 only starting from 2.3, package `php-http/httplug` also needed an update.
Though major versions change, it looks like it doesn't affect this bundle - I ran all 13 tests, looked at imported classes, and it seems to be fine.