### PR TITLE
Remove request_stack service definition check

### DIFF
--- a/DependencyInjection/Auto1ServiceAPIClientExtension.php
+++ b/DependencyInjection/Auto1ServiceAPIClientExtension.php
@@ -26,14 +26,5 @@ class Auto1ServiceAPIClientExtension extends Extension
         $container->setParameter('auto1_service_api_client.request_visitors', $config['request_visitors']);
         $container->setParameter('auto1_service_api_client.propagate_headers', $config['propagate_headers']);
         $container->setParameter('auto1_service_api_client.request_time_log_level', $config['request_time_log_level']);
-
-        /*
-         * Headers to propagate are by default taken from @request_stack if exists
-         * so if there is no initial request - all related service definitions will be removed
-         */
-        if (!$container->hasDefinition('request_stack')) {
-            $container->removeDefinition('auto1.api.request.visitor.header_propagation');
-            $container->removeDefinition('auto1.api.previous_request');
-        }
     }
 }


### PR DESCRIPTION
I propose to remove this check as starting from Symfony 2.4 `request_stack` is always present.

Service `request_stack` is registered in `symfony/http-foundation` which is required by `symfony/http-kernel` from [composer.json](https://github.com/auto1-oss/service-api-client-bundle/blob/280d6f0740a6ce3d98cb0b0422b79397934beba0/composer.json#L28).

At the same time I want to highlight that `$container` in Extension is not fulfilled container.
It's a [temporary container](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php#L76) which doesn't have all previously registered services.

In my case I don't see `request_stack` in this temporary container when I'm using SF 4.4.

It causes next error because this code removes neccessery services:
```
  You have requested a non-existent service "auto1.api.request.visitor.header_propagation".  
```

The right place for such checks is [Compiler Passes](https://symfony.com/doc/current/components/dependency_injection/compilation.html#managing-configuration-with-extensions)

Because as per documentation:
```
The load() method is passed a fresh container to set up, which is then merged afterwards into the container it is registered with.
```

/cc @Dropaq 
