### PR TITLE
Update default exception message

### DIFF
--- a/Exception/ResponseException.php
+++ b/Exception/ResponseException.php
@@ -25,6 +25,12 @@ class ResponseException extends AbstractException
      */
     public function __construct(ErrorResponse $errorDto = null, $code = 0, $message = null, \Throwable $previous = null)
     {
-        parent::__construct($message ?: ($errorDto ? $errorDto->getMessage() : null), $code, $previous);
+        if ($message === null) {
+            $message = $errorDto
+                ? $errorDto->getMessage() ?? ''
+                : '';
+        }
+
+        parent::__construct($message, $code, $previous);
     }
 }


### PR DESCRIPTION
Since 8.1 isn't possible to pass a null to the parameter of type string
https://3v4l.org/qEUOI