### PR TITLE
Support array query params

### DIFF
--- a/Service/Request/RequestFactory.php
+++ b/Service/Request/RequestFactory.php
@@ -182,7 +182,7 @@ class RequestFactory implements RequestFactoryInterface
 
         if (null !== $queryParamsString) {
             parse_str($queryParamsString, $queryParamsArray);
-            $queryParamsArray = $this->normalize_queryParams($queryParamsArray);
+            $queryParamsArray = $this->normalizeQueryParams($queryParamsArray);
             $queryParamsArray = array_filter($queryParamsArray, [$this, 'filterQueryParamConstant']);
             $queryParamsArray = array_map([$this, 'trimCurlyBrackets'], $queryParamsArray);
 
@@ -217,7 +217,7 @@ class RequestFactory implements RequestFactoryInterface
      *
      * @return array
      */
-    private function normalize_queryParams($queryParamsArray)
+    private function normalizeQueryParams($queryParamsArray)
     {
         $return = array();
         array_walk_recursive($queryParamsArray, function($a) use (&$return) { $return[] = $a; });

--- a/Service/Request/RequestFactory.php
+++ b/Service/Request/RequestFactory.php
@@ -217,9 +217,9 @@ class RequestFactory implements RequestFactoryInterface
      *
      * @return array
      */
-    private function normalizeQueryParams($queryParamsArray)
+    private function normalizeQueryParams(array $queryParamsArray): array
     {
-        $return = array();
+        $return = [];
         array_walk_recursive($queryParamsArray, function($a) use (&$return) { $return[] = $a; });
 
         return $return;

--- a/Service/Request/RequestFactory.php
+++ b/Service/Request/RequestFactory.php
@@ -182,6 +182,7 @@ class RequestFactory implements RequestFactoryInterface
 
         if (null !== $queryParamsString) {
             parse_str($queryParamsString, $queryParamsArray);
+            $queryParamsArray = $this->normalize_queryParams($queryParamsArray);
             $queryParamsArray = array_filter($queryParamsArray, [$this, 'filterQueryParamConstant']);
             $queryParamsArray = array_map([$this, 'trimCurlyBrackets'], $queryParamsArray);
 
@@ -209,5 +210,17 @@ class RequestFactory implements RequestFactoryInterface
     private function trimCurlyBrackets($str)
     {
         return trim($str, '{}');
+    }
+
+    /**
+     * @param array $queryParamsString
+     *
+     * @return array
+     */
+    private function normalize_queryParams($queryParamsArray)
+    {
+        $return = array();
+        array_walk_recursive($queryParamsArray, function($a) use (&$return) { $return[] = $a; });
+        return $return;
     }
 }

--- a/Service/Request/RequestFactory.php
+++ b/Service/Request/RequestFactory.php
@@ -221,6 +221,7 @@ class RequestFactory implements RequestFactoryInterface
     {
         $return = array();
         array_walk_recursive($queryParamsArray, function($a) use (&$return) { $return[] = $a; });
+
         return $return;
     }
 }

--- a/Tests/Service/Request/RequestFactoryTest.php
+++ b/Tests/Service/Request/RequestFactoryTest.php
@@ -166,14 +166,14 @@ class RequestFactoryTest extends TestCase
     public function testBuildFlowWithQueryParams()
     {
         $baseUrl = 'baseUrl';
-        $routeString = '/routeString?first-param={firstParam}&second-param=ignored value&arr-param[key]={arrParam}&dot.seprate[0].array={dotParam}';
+        $routeString = '/routeString?first-param={firstParam}&second-param=ignored value&arr-param[key]={arrParam}&dot.seprate[0].array={dotSeparatedArrayParam}';
         $originParamValue = 'value with whitespaces';
         $originArrParamValue = 'arrValue';
-        $originDotParamValue = 'dotValue';
+        $origindotSeparatedArrayParam = 'dotSeparatedArrayValue';
         $requestMethod = 'GET';
         $requestBody = '';
 
-        $expectedUri = 'baseUrl/routeString?first-param=value+with+whitespaces&second-param=ignored value&arr-param[key]=arrValue&dot.seprate[0].array=dotValue';
+        $expectedUri = 'baseUrl/routeString?first-param=value+with+whitespaces&second-param=ignored value&arr-param[key]=arrValue&dot.seprate[0].array=dotSeparatedArrayValue';
 
         $endpointProphecy = $this->prophesize(EndpointInterface::class);
         $endpointProphecy->__call('getBaseUrl', [])
@@ -238,7 +238,7 @@ class RequestFactoryTest extends TestCase
 
         // Mock non existing method of ServiceRequest `getParam`
         $serviceRequest = $this->getMockBuilder(ServiceRequestInterface::class)
-            ->setMethods(['getFirstParam', 'getArrParam', 'getDotParam'])
+            ->setMethods(['getFirstParam', 'getArrParam', 'getDotSeparatedArrayParam'])
             ->getMock()
         ;
 
@@ -253,8 +253,8 @@ class RequestFactoryTest extends TestCase
         ;
 
         $serviceRequest->expects($this->once())
-            ->method('getDotParam')
-            ->willReturn($originDotParamValue)
+            ->method('getDotSeparatedArrayParam')
+            ->willReturn($origindotSeparatedArrayParam)
         ;
 
         $requestBuilder = new RequestFactory(

--- a/Tests/Service/Request/RequestFactoryTest.php
+++ b/Tests/Service/Request/RequestFactoryTest.php
@@ -166,14 +166,14 @@ class RequestFactoryTest extends TestCase
     public function testBuildFlowWithQueryParams()
     {
         $baseUrl = 'baseUrl';
-        $routeString = '/routeString?first-param={firstParam}&second-param=ignored value&arr-param[key]={arrParam}&dot.seprate[0].array={dotSeparatedArrayParam}';
+        $routeString = '/routeString?first-param={firstParam}&second-param=ignored value&arr-param[key1]={arrParam1}&arr-param[key2]={arrParam2}';
         $originParamValue = 'value with whitespaces';
-        $originArrParamValue = 'arrValue';
-        $origindotSeparatedArrayParam = 'dotSeparatedArrayValue';
+        $originArrParam1Value = 'arrValue1';
+        $originArrParam2Value = 'arrValue2';
         $requestMethod = 'GET';
         $requestBody = '';
 
-        $expectedUri = 'baseUrl/routeString?first-param=value+with+whitespaces&second-param=ignored value&arr-param[key]=arrValue&dot.seprate[0].array=dotSeparatedArrayValue';
+        $expectedUri = 'baseUrl/routeString?first-param=value+with+whitespaces&second-param=ignored value&arr-param[key1]=arrValue1&arr-param[key2]=arrValue2';
 
         $endpointProphecy = $this->prophesize(EndpointInterface::class);
         $endpointProphecy->__call('getBaseUrl', [])
@@ -238,7 +238,7 @@ class RequestFactoryTest extends TestCase
 
         // Mock non existing method of ServiceRequest `getParam`
         $serviceRequest = $this->getMockBuilder(ServiceRequestInterface::class)
-            ->setMethods(['getFirstParam', 'getArrParam', 'getDotSeparatedArrayParam'])
+            ->setMethods(['getFirstParam', 'getArrParam1', 'getArrParam2'])
             ->getMock()
         ;
 
@@ -248,13 +248,13 @@ class RequestFactoryTest extends TestCase
         ;
 
         $serviceRequest->expects($this->once())
-            ->method('getArrParam')
-            ->willReturn($originArrParamValue)
+            ->method('getArrParam1')
+            ->willReturn($originArrParam1Value)
         ;
 
         $serviceRequest->expects($this->once())
-            ->method('getDotSeparatedArrayParam')
-            ->willReturn($origindotSeparatedArrayParam)
+            ->method('getArrParam2')
+            ->willReturn($originArrParam2Value)
         ;
 
         $requestBuilder = new RequestFactory(

--- a/Tests/Service/Request/RequestFactoryTest.php
+++ b/Tests/Service/Request/RequestFactoryTest.php
@@ -166,13 +166,14 @@ class RequestFactoryTest extends TestCase
     public function testBuildFlowWithQueryParams()
     {
         $baseUrl = 'baseUrl';
-        $routeString = '/routeString?first-param={firstParam}&second-param=ignored value&arr-param[key]={arrParam}';
+        $routeString = '/routeString?first-param={firstParam}&second-param=ignored value&arr-param[key]={arrParam}&dot.seprate[0].array={dotParam}';
         $originParamValue = 'value with whitespaces';
         $originArrParamValue = 'arrValue';
+        $originDotParamValue = 'dotValue';
         $requestMethod = 'GET';
         $requestBody = '';
 
-        $expectedUri = 'baseUrl/routeString?first-param=value+with+whitespaces&second-param=ignored value&arr-param[key]=arrValue';
+        $expectedUri = 'baseUrl/routeString?first-param=value+with+whitespaces&second-param=ignored value&arr-param[key]=arrValue&dot.seprate[0].array=dotValue';
 
         $endpointProphecy = $this->prophesize(EndpointInterface::class);
         $endpointProphecy->__call('getBaseUrl', [])
@@ -237,7 +238,7 @@ class RequestFactoryTest extends TestCase
 
         // Mock non existing method of ServiceRequest `getParam`
         $serviceRequest = $this->getMockBuilder(ServiceRequestInterface::class)
-            ->setMethods(['getFirstParam', 'getArrParam'])
+            ->setMethods(['getFirstParam', 'getArrParam', 'getDotParam'])
             ->getMock()
         ;
 
@@ -249,6 +250,11 @@ class RequestFactoryTest extends TestCase
         $serviceRequest->expects($this->once())
             ->method('getArrParam')
             ->willReturn($originArrParamValue)
+        ;
+
+        $serviceRequest->expects($this->once())
+            ->method('getDotParam')
+            ->willReturn($originDotParamValue)
         ;
 
         $requestBuilder = new RequestFactory(

--- a/Tests/Service/Request/RequestFactoryTest.php
+++ b/Tests/Service/Request/RequestFactoryTest.php
@@ -166,12 +166,13 @@ class RequestFactoryTest extends TestCase
     public function testBuildFlowWithQueryParams()
     {
         $baseUrl = 'baseUrl';
-        $routeString = '/routeString?first-param={firstParam}&second-param=ignored value';
+        $routeString = '/routeString?first-param={firstParam}&second-param=ignored value&arr-param[key]={arrParam}';
         $originParamValue = 'value with whitespaces';
+        $originArrParamValue = 'arrValue';
         $requestMethod = 'GET';
         $requestBody = '';
 
-        $expectedUri = 'baseUrl/routeString?first-param=value+with+whitespaces&second-param=ignored value';
+        $expectedUri = 'baseUrl/routeString?first-param=value+with+whitespaces&second-param=ignored value&arr-param[key]=arrValue';
 
         $endpointProphecy = $this->prophesize(EndpointInterface::class);
         $endpointProphecy->__call('getBaseUrl', [])
@@ -236,13 +237,18 @@ class RequestFactoryTest extends TestCase
 
         // Mock non existing method of ServiceRequest `getParam`
         $serviceRequest = $this->getMockBuilder(ServiceRequestInterface::class)
-            ->setMethods(['getFirstParam'])
+            ->setMethods(['getFirstParam', 'getArrParam'])
             ->getMock()
         ;
 
         $serviceRequest->expects($this->once())
             ->method('getFirstParam')
             ->willReturn($originParamValue)
+        ;
+
+        $serviceRequest->expects($this->once())
+            ->method('getArrParam')
+            ->willReturn($originArrParamValue)
         ;
 
         $requestBuilder = new RequestFactory(


### PR DESCRIPTION
Current implementation fails to process array types on the query string. This is due that `parse_str` function returns the parameter as an array and the next steps fail since only can process string.
Adding a normalizing the array  by flatting it allows to get the desire values in all levels of the array configuration for the parameter.