### PR TITLE
Format DateTimeInterface and drop null query parameters

### DIFF
--- a/Service/Request/RequestFactory.php
+++ b/Service/Request/RequestFactory.php
@@ -165,9 +165,18 @@ class RequestFactory implements RequestFactoryInterface, LoggerAwareInterface
             if ($value instanceof \DateTimeInterface) {
                 $value = $value->format($endpoint->getDateTimeFormat() ?: \DATE_ATOM);
             }
-            $value = array_key_exists($property, $queryParams) ? urlencode((string)$value) : $value;
+            if (array_key_exists($property, $queryParams)) {
+                if (null === $value) {
+                    $path = str_replace($queryParams[$property].'='.$placeholder, '', $path);
+
+                    continue;
+                }
+                $value = urlencode((string)$value);
+            }
             $path = str_replace($placeholder, $value, $path);
         }
+
+        $path = $this->normalizeQueryString($path);
 
         if (!$this->validateEndpointPath($path)) {
             $message = 'Invalid request path';
@@ -213,6 +222,21 @@ class RequestFactory implements RequestFactoryInterface, LoggerAwareInterface
         $pathContainsEmptyFolders = preg_match('/\/\//', $path);
 
         return !$pathContainsUnmappedArguments && !$pathContainsEmptyFolders;
+    }
+
+    /**
+     * Removes query string separator artifacts left behind when a parameter is dropped
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    private function normalizeQueryString(string $path): string
+    {
+        $path = (string)preg_replace('/&{2,}/', '&', $path);
+        $path = str_replace('?&', '?', $path);
+
+        return rtrim($path, '?&');
     }
 
     /**

--- a/Service/Request/RequestFactory.php
+++ b/Service/Request/RequestFactory.php
@@ -162,6 +162,9 @@ class RequestFactory implements RequestFactoryInterface, LoggerAwareInterface
                 throw new InvalidArgumentException($message, $errorCode);
             }
             $value = $serviceRequest->$getterMethod();
+            if ($value instanceof \DateTimeInterface) {
+                $value = $value->format($endpoint->getDateTimeFormat() ?: \DATE_ATOM);
+            }
             $value = array_key_exists($property, $queryParams) ? urlencode((string)$value) : $value;
             $path = str_replace($placeholder, $value, $path);
         }

--- a/Tests/Service/Request/RequestFactoryTest.php
+++ b/Tests/Service/Request/RequestFactoryTest.php
@@ -632,4 +632,88 @@ class RequestFactoryTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * @dataProvider nullQueryParamProvider
+     *
+     * @return void
+     */
+    public function testNullQueryParamIsDropped(string $routeString, ?string $second, string $expectedUri): void
+    {
+        $baseUrl = 'baseUrl';
+        $requestMethod = 'GET';
+        $requestBody = '';
+
+        $endpointProphecy = $this->prophesize(EndpointInterface::class);
+        $endpointProphecy->getBaseUrl()->willReturn($baseUrl)->shouldBeCalled();
+        $endpointProphecy->getPath()->willReturn($routeString)->shouldBeCalled();
+        $endpointProphecy->getMethod()->willReturn($requestMethod)->shouldBeCalled();
+        $endpointProphecy->getRequestFormat()->willReturn(EndpointInterface::FORMAT_JSON)->shouldBeCalled();
+        $endpoint = $endpointProphecy->reveal();
+
+        $uri = $this->prophesize(UriInterface::class)->reveal();
+        $requestProphecy = $this->prophesize(RequestInterface::class);
+        $request = $requestProphecy->reveal();
+        $stream = $this->prophesize(StreamInterface::class)->reveal();
+
+        $serviceRequest = $this->getMockBuilder(ServiceRequestInterface::class)
+            ->addMethods(['getFirstParam', 'getSecondParam'])
+            ->getMock();
+
+        $serviceRequest->method('getFirstParam')->willReturn(null);
+        $serviceRequest->method('getSecondParam')->willReturn($second);
+
+        $this->endpointRegistryProphecy->getEndpoint($serviceRequest)->willReturn($endpoint)->shouldBeCalled();
+        $this->serializerProphecy
+            ->serialize($serviceRequest, EndpointInterface::FORMAT_JSON)
+            ->willReturn($requestBody)
+            ->shouldBeCalled()
+        ;
+        $this->uriFactoryProphecy->createUri($expectedUri)->willReturn($uri)->shouldBeCalled();
+        $this->requestFactoryProphecy->createRequest($requestMethod, $uri)->willReturn($request)->shouldBeCalled();
+        $this->streamFactoryProphecy->createStream($requestBody)->willReturn($stream)->shouldBeCalled();
+        $requestProphecy->withBody($stream)->willReturn($request)->shouldBeCalled();
+        $this->requestVisitorRegistryProphecy
+            ->getRegisteredRequestVisitors(EndpointInterface::FORMAT_JSON)
+            ->willReturn([])
+            ->shouldBeCalled()
+        ;
+        $this->requestDecoratorProphecy->visit($request)->shouldNotBeCalled();
+
+        $requestBuilder = new RequestFactory(
+            $this->endpointRegistryProphecy->reveal(),
+            $this->serializerProphecy->reveal(),
+            $this->requestVisitorRegistryProphecy->reveal(),
+            $this->uriFactoryProphecy->reveal(),
+            $this->requestFactoryProphecy->reveal(),
+            $this->streamFactoryProphecy->reveal(),
+            false
+        );
+
+        $this->assertInstanceOf(RequestInterface::class, $requestBuilder->create($serviceRequest));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string|null, 2: string}>
+     */
+    public function nullQueryParamProvider(): array
+    {
+        return [
+            'only param is dropped, no trailing question mark' => [
+                '/rates?first_param={firstParam}',
+                null,
+                'baseUrl/rates',
+            ],
+            'leading param is dropped, no stray ampersand' => [
+                '/rates?first_param={firstParam}&second_param={secondParam}',
+                'kept',
+                'baseUrl/rates?second_param=kept',
+            ],
+            'both dropped leaves a bare path' => [
+                '/rates?first_param={firstParam}&second_param={secondParam}',
+                null,
+                'baseUrl/rates',
+            ],
+        ];
+    }
 }

--- a/Tests/Service/Request/RequestFactoryTest.php
+++ b/Tests/Service/Request/RequestFactoryTest.php
@@ -554,4 +554,82 @@ class RequestFactoryTest extends TestCase
             $requestBuilder->create($this->serviceRequestProphecy->reveal())
         );
     }
+
+    /**
+     * @dataProvider dateTimeQueryParamProvider
+     *
+     * @return void
+     */
+    public function testDateTimeQueryParamIsFormatted(?string $dateTimeFormat, string $expectedUri): void
+    {
+        $baseUrl = 'baseUrl';
+        $routeString = '/rates?markup_date={markupDate}';
+        $requestMethod = 'GET';
+        $requestBody = '';
+
+        $endpointProphecy = $this->prophesize(EndpointInterface::class);
+        $endpointProphecy->getBaseUrl()->willReturn($baseUrl)->shouldBeCalled();
+        $endpointProphecy->getPath()->willReturn($routeString)->shouldBeCalled();
+        $endpointProphecy->getMethod()->willReturn($requestMethod)->shouldBeCalled();
+        $endpointProphecy->getRequestFormat()->willReturn(EndpointInterface::FORMAT_JSON)->shouldBeCalled();
+        $endpointProphecy->getDateTimeFormat()->willReturn($dateTimeFormat)->shouldBeCalled();
+        $endpoint = $endpointProphecy->reveal();
+
+        $uri = $this->prophesize(UriInterface::class)->reveal();
+        $requestProphecy = $this->prophesize(RequestInterface::class);
+        $request = $requestProphecy->reveal();
+        $stream = $this->prophesize(StreamInterface::class)->reveal();
+
+        $serviceRequest = $this->getMockBuilder(ServiceRequestInterface::class)
+            ->addMethods(['getMarkupDate'])
+            ->getMock();
+
+        $serviceRequest
+            ->expects($this->once())
+            ->method('getMarkupDate')
+            ->willReturn(new \DateTimeImmutable('2026-03-12T15:09:26+01:00'));
+
+        $this->endpointRegistryProphecy->getEndpoint($serviceRequest)->willReturn($endpoint)->shouldBeCalled();
+        $this->serializerProphecy
+            ->serialize($serviceRequest, EndpointInterface::FORMAT_JSON)
+            ->willReturn($requestBody)
+            ->shouldBeCalled()
+        ;
+        $this->uriFactoryProphecy->createUri($expectedUri)->willReturn($uri)->shouldBeCalled();
+        $this->requestFactoryProphecy->createRequest($requestMethod, $uri)->willReturn($request)->shouldBeCalled();
+        $this->streamFactoryProphecy->createStream($requestBody)->willReturn($stream)->shouldBeCalled();
+        $requestProphecy->withBody($stream)->willReturn($request)->shouldBeCalled();
+        $this->requestVisitorRegistryProphecy
+            ->getRegisteredRequestVisitors(EndpointInterface::FORMAT_JSON)
+            ->willReturn([])
+            ->shouldBeCalled()
+        ;
+        $this->requestDecoratorProphecy->visit($request)->shouldNotBeCalled();
+
+        $requestBuilder = new RequestFactory(
+            $this->endpointRegistryProphecy->reveal(),
+            $this->serializerProphecy->reveal(),
+            $this->requestVisitorRegistryProphecy->reveal(),
+            $this->uriFactoryProphecy->reveal(),
+            $this->requestFactoryProphecy->reveal(),
+            $this->streamFactoryProphecy->reveal(),
+            false
+        );
+
+        $this->assertInstanceOf(RequestInterface::class, $requestBuilder->create($serviceRequest));
+    }
+
+    /**
+     * @return array<string, array{0: string|null, 1: string}>
+     */
+    public function dateTimeQueryParamProvider(): array
+    {
+        return [
+            'endpoint format is used' => ['Y-m-d', 'baseUrl/rates?markup_date=2026-03-12'],
+            'falls back to ATOM when the endpoint declares none' => [
+                null,
+                'baseUrl/rates?markup_date=2026-03-12T15%3A09%3A26%2B01%3A00',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
`RequestFactory::getRequestUri()` renders query placeholders with `urlencode((string) $value)`.

- A `DateTimeInterface` cannot be cast to string, so any endpoint with a date query parameter dies
with `Object of class DateTime could not be converted to string`, so the request is never sent.

- A `null` casts to an empty string, so the parameter goes out as `param=` instead of being omitted.
This drops it from the query string instead, the way #46 already does for empty arrays.

Given an endpoint path `/items?created_at={createdAt}&status={status}&page={page}`:

| values | before | after |
|---|---|---|
| `createdAt` is a `DateTimeImmutable` | fatal error, no request sent | `/items?created_at=2026-03-12&…` |
| `status` is `null` | `/items?…&status=&page=1` | `/items?…&page=1` |
| every optional value is `null` | `/items?created_at=&status=&page=` | `/items` |

The date format comes from the endpoint's own `dateTimeFormat`, falling back to `DATE_ATOM`.